### PR TITLE
Fixed  #1, issue with zoxide changing distribution method

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,8 +42,9 @@ build() {
   _ostype=unknown-linux-$_clibtype
   _target="$_cputype-$_ostype"
   rm -rf "zoxide-$_target"
+
   curl -s https://api.github.com/repos/ajeetdsouza/zoxide/releases/latest | grep "browser_download_url" | cut -d '"' -f 4 | grep "$_target" | xargs -n 1 curl -LJO
-  mv "zoxide-$_target" "zoxide"
+  tar -xf zoxide-*.tar.gz zoxide
   chmod +x zoxide
 
 }


### PR DESCRIPTION
Fixes #1 

Long story short, zoxide changed how they distribute binaries, now they release tarballs that contain the binary and other files instead of just a sole binary. This change downloads the tarball then extracts the binary from the tarlball and has been tested on my setup. I think it should work from now on, at least until they change something again :P