### PR TITLE
`cd $CDIR` before copying prerun files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,10 +27,8 @@ build() {
   rm -rf $build_dir
   mkdir -p $build_dir
 
-  for f in *prerun.sh *pluginrc.*
-  do
-      cp $CDIR/$f $build_dir/
-  done
+  cd $CDIR
+  cp *prerun.sh *pluginrc.* $build_dir/
 
   cd $build_dir
 


### PR DESCRIPTION
Update from https://github.com/xxh/cookiecutter-xxh-plugin-prerun/pull/1.